### PR TITLE
chore: fix deprecated interpolation-only expressions

### DIFF
--- a/billing.tf
+++ b/billing.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "s3bucket-policy" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "${aws_s3_bucket.cost-report.arn}"
+      aws_s3_bucket.cost-report.arn
     ]
   }
   statement {

--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "cloudtrail-bucket-policy" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "${aws_s3_bucket.cloudtrail-bucket.arn}"
+      aws_s3_bucket.cloudtrail-bucket.arn
     ]
   }
   statement {

--- a/config.tf
+++ b/config.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "config-bucket-policy" {
       "s3:GetBucketAcl"
     ]
     resources = [
-      "${aws_s3_bucket.config-bucket.arn}"
+      aws_s3_bucket.config-bucket.arn
     ]
   }
   statement {
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "config-bucket-policy" {
       "s3:ListBucket"
     ]
     resources = [
-      "${aws_s3_bucket.config-bucket.arn}"
+      aws_s3_bucket.config-bucket.arn
     ]
   }
   statement {


### PR DESCRIPTION
Warning: Interpolation-only expressions are deprecated

  on billing.tf line 40, in data "aws_iam_policy_document" "s3bucket-policy":
  40:       "${aws_s3_bucket.cost-report.arn}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and 3 more similar warnings elsewhere)