### PR TITLE
fix: auto enable guardduty for organization

### DIFF
--- a/modules/aws/guardduty/main.tf
+++ b/modules/aws/guardduty/main.tf
@@ -4,6 +4,11 @@ resource "aws_guardduty_detector" "guardduty" {
   enable = true
 }
 
+resource "aws_guardduty_organization_configuration" "org-gd" {
+  auto_enable = true
+  detector_id = aws_guardduty_detector.guardduty.id
+}
+
 resource "aws_cloudformation_stack" "amazon-guardduty-to-slack" {
   name = "amazon-guardduty-to-slack"
   capabilities = ["CAPABILITY_IAM"]


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration