### PR TITLE
fix: add dependencies on aws_guardduty_organization_admin_account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,12 +89,20 @@ resource "aws_organizations_organizational_unit" "dev" {
   parent_id = aws_organizations_organization.org.roots[0].id
 }
 
+resource "aws_guardduty_organization_admin_account" "root" {
+  depends_on = [aws_organizations_organization.org]
+
+  admin_account_id = var.org_admin_id
+}
+
 module "virginia" {
   source = "./modules/aws/guardduty"
   providers = {
     aws = aws.Virginia
   }
   slack_aws_alert_url = var.slack_aws_alert_url
+
+  depends_on = [aws_guardduty_organization_admin_account.root]
 }
 
 module "tokyo" {
@@ -103,10 +111,6 @@ module "tokyo" {
     aws = aws.Tokyo
   }
   slack_aws_alert_url = var.slack_aws_alert_url
-}
 
-resource "aws_guardduty_organization_admin_account" "root" {
-  depends_on = [aws_organizations_organization.org]
-
-  admin_account_id = var.org_admin_id
+  depends_on = [aws_guardduty_organization_admin_account.root]
 }


### PR DESCRIPTION
Error: error updating GuardDuty Organization Configuration (30b8ec9fec3882eded649f71872e1938): BadRequestException: The request failed because a delegated administrator account has not been enabled.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "c51102c5-a779-4ed8-a967-fe5f2948769c"
  },
  Message_: "The request failed because a delegated administrator account has not been enabled.",
  Type: "InvalidInputException"
}