### PR TITLE
AWS Chatbot利用開始に伴う不要リソース削除

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,6 +62,4 @@ jobs:
 
     - name: Terraform Plan
       id: plan
-      env:
-        TF_VAR_slack_aws_alert_url: ${{ secrets.SLACK_AWS_ALERT_URL }}
       run: terraform plan -no-color

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,4 @@ jobs:
 
     - name: Terraform Apply
       id: apply
-      env:
-        TF_VAR_slack_aws_alert_url: ${{ secrets.SLACK_AWS_ALERT_URL }}
       run: terraform apply -auto-approve

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "virginia" {
   providers = {
     aws = aws.Virginia
   }
-  aws_account_id      = data.aws_caller_identity.self.account_id
+  aws_account_id = data.aws_caller_identity.self.account_id
 }
 
 module "tokyo" {
@@ -43,5 +43,5 @@ module "tokyo" {
   providers = {
     aws = aws.Tokyo
   }
-  aws_account_id      = data.aws_caller_identity.self.account_id
+  aws_account_id = data.aws_caller_identity.self.account_id
 }

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,6 @@ module "virginia" {
     aws = aws.Virginia
   }
   aws_account_id      = data.aws_caller_identity.self.account_id
-  slack_aws_alert_url = var.slack_aws_alert_url
 }
 
 module "tokyo" {
@@ -45,5 +44,4 @@ module "tokyo" {
     aws = aws.Tokyo
   }
   aws_account_id      = data.aws_caller_identity.self.account_id
-  slack_aws_alert_url = var.slack_aws_alert_url
 }

--- a/modules/aws/guardduty/main.tf
+++ b/modules/aws/guardduty/main.tf
@@ -1,14 +1,3 @@
 resource "aws_guardduty_detector" "guardduty" {
   enable = true
 }
-
-resource "aws_cloudformation_stack" "amazon-guardduty-to-slack" {
-  name = "amazon-guardduty-to-slack"
-  capabilities = ["CAPABILITY_IAM"]
-  parameters = {
-    IncomingWebHookURL = var.slack_aws_alert_url
-    SlackChannel = "#alert-aws"
-    MinSeverityLevel = "LOW"
-  }
-  template_url = "https://outside-code-management.s3.ap-northeast-1.amazonaws.com/gd2slack.template"
-}

--- a/modules/aws/guardduty/variables.tf
+++ b/modules/aws/guardduty/variables.tf
@@ -1,2 +1,1 @@
 variable "aws_account_id" {}
-variable "slack_aws_alert_url" {}

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,0 @@
-variable "slack_aws_alert_url" {}


### PR DESCRIPTION
GuardDutyのイベント検出時にSlack Incoming WebHookを利用していた。